### PR TITLE
Generate unique labels with `${:uid}`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,8 @@ version = "0.1.0"
 julia = "1"
 
 [extras]
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "InteractiveUtils"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using AsmMacro, Test
+using AsmMacro, Test, InteractiveUtils
 
 @testset "@asm" begin
     @asm function add_loop_vec4(x::Ptr{Float64},n::Int,z::Ptr{Float64})
@@ -21,6 +21,7 @@ using AsmMacro, Test
     z = similar(x)
     add_loop_vec4(pointer(x),n,pointer(z))
     @test z == x*n
+    @test occursin("\${:uid}", sprint(code_llvm, add_loop_vec4, (Ptr{Float64}, Int, Ptr{Float64})))
 
     @asm function add(z::Ptr{Int64}, x::Int64, y::Int64)
         addq(x, y)


### PR DESCRIPTION
https://llvm.org/docs/LangRef.html#inline-assembler-expressions

> ${:uid}: Expands to a decimal integer unique to this inline assembly blob.
> This substitution is useful when declaring a local label. Many standard
> compiler optimizations, such as inlining, may duplicate an inline asm blob.
> Adding a blob-unique identifier ensures that the two labels will not conflict
> during assembly. This is used to implement GCC’s %= special format string.